### PR TITLE
Sync documentation with code

### DIFF
--- a/admin-panel/documentation/pages/1-getting-started.md
+++ b/admin-panel/documentation/pages/1-getting-started.md
@@ -1,0 +1,58 @@
+# Getting Started
+
+Welcome to the Church Theme. This page walks you through the first few things to set up after the theme is activated, so the rest of the site behaves the way you expect.
+
+## A quick tour of where things live
+
+You will spend most of your time in three places:
+
+- **Posts, Pages, and the other content menus in the sidebar** — where you write content. The theme adds extra menus here for the kinds of content it knows about (sermons, events, staff, and so on).
+- **Appearance → Customize** — where you change how the site looks: colors, fonts, hero areas, headers, footers, and the styling for each kind of content. See the *Customizer* page for an overview of what is in each section.
+- **Settings → Theme Settings** — where you turn the theme's content types on or off, and where you can back up or restore your styling choices. See the *Theme Settings* page.
+
+There is also a **Documentation** menu (just below Settings) — that is where you are right now.
+
+## First-time setup
+
+There are three small setup steps the theme needs before everything works correctly. The theme will show you reminder notices at the top of the admin screen for any of these that still need doing.
+
+### 1. Set your permalinks
+
+Go to **Settings → Permalinks** and choose **Post name**. The theme's archive pages (such as the sermons list or events list) rely on this setting — if permalinks are set to anything else, those pages will not load properly.
+
+### 2. Create the archive pages
+
+The big banner image at the top of each archive page (the sermons list, events list, staff list, and so on) is taken from a regular page whose slug matches the content type. For example, the sermons archive uses a page with the slug `sermons`.
+
+You do not need to remember any of this. When an archive page is missing, the theme shows a notice at the top of the admin with a button to create it for you. Click the button, set a featured image on the new page, and the archive will use that image as its banner.
+
+The same applies to a **404 page**: the theme shows a notice if a page with the slug `404-page` does not exist, and offers to create it for you.
+
+### 3. Choose which content types you use
+
+Not every church needs every kind of content. Go to **Settings → Theme Settings** and tick the content types you want available: *sermons*, *sermon-series*, *ministries*, *events*, and *staff*. Anything you leave unticked is hidden from the admin entirely, so the sidebar stays focused on what you actually use. You can change this at any time.
+
+## Setting up your menu
+
+Go to **Appearance → Menus** and build your primary navigation. Be sure to assign it to the **Primary Menu** location at the bottom of the menus page — the theme will show a notice at the top of the admin until you do.
+
+## Making the site look like yours
+
+Open **Appearance → Customize** and work through the sections to set:
+
+- **Church Info** — your church name, telephone, email, and address.
+- **Site Colors** — the main color palette for the whole site.
+- **Font Settings** — which fonts the site uses for headings, body text, and menus.
+- **Header Settings** — your logo and the header layout.
+- **Footer Settings** — copyright text and links to your social media accounts.
+
+There is a lot more available in the Customizer. The *Customizer* page in this documentation has a section-by-section overview to help you find what you need.
+
+## What to read next
+
+- **Customizer** — every Customizer section explained.
+- **Theme Settings** — turning content types on and off, plus backing up and restoring your settings.
+- **Layouts** — show the same block of content automatically across many pages without editing each one.
+- **Patterns** — redesign parts of the site (footer, sermon pages, tiles) visually, without code.
+- **Blocks** — the extra editor blocks the theme adds.
+- **Managing Sermons / Events / Notifications** — the day-to-day content guides for each section.

--- a/admin-panel/documentation/pages/3-customizer.md
+++ b/admin-panel/documentation/pages/3-customizer.md
@@ -1,0 +1,132 @@
+# Customizer
+
+The **Customizer** is where almost every styling choice on the site lives — colors, fonts, header and footer, the look of the hero banner, the cards on each archive, and much more. Open it from **Appearance → Customize**.
+
+The Customizer shows a live preview of the site on the right while you make changes on the left. Nothing is saved until you click **Publish** at the top — feel free to try things out.
+
+## Brand and identity
+
+These are the first sections to fill in, because they set the look that the rest of the site builds on.
+
+### Church Info
+
+Your church's name, telephone number, email address, and street address. Several places on the site pull these in automatically (for example the footer and contact pages).
+
+### Site Colors
+
+A two-step color system. First you set a small palette of **base colors** (your primary tint, a secondary tint, accent, whites, greys, and a few outline colors for accessibility). Then, further down the section, you pick which base color is used for each individual area of the site — header background, menu links, hero text, card backgrounds, button colors, footer text, and so on.
+
+The base colors you set here are also added to the color picker that appears in the block editor, so the same palette is available when you write a page or post.
+
+### Font Settings
+
+The fonts the site uses. You can configure three font families (using Google Fonts embed parameters) and then choose which one is used for general body text, headings, blockquote quotation marks, and the header menu. You can also set heading sizes, line height, letter spacing, and whether headings are upper-case.
+
+## Overall layout
+
+### General Settings
+
+Site-wide values that affect every page:
+
+- **Content Width** — how wide the main content area is.
+- **Bible Version Used** — which translation Bible references on the site link to (ASV, ESV, KJV, NIV, NKJV, or YLT).
+- **Page Sidebar Position** — whether the sidebar appears on the left or the right.
+- **Image Parallax Effect** — turn the parallax scroll effect on or off for hero images.
+- **Base Font Size** and **Padding** controls — set the baseline values everything else scales from.
+- **Border Widths** and **Border Radius** — three sizes each (small, medium, wide / small, medium, large) used consistently throughout the site.
+
+### Header Settings
+
+Everything about the bar at the top of every page:
+
+- **Fixed Header** — keep the header pinned to the top as the visitor scrolls, on every screen size, on desktop only, or not at all.
+- **Transparent Fixed Header** — let the hero image show through the fixed header when one is present.
+- **Header Logo Image** — upload your logo.
+- **Logo Sizes** — separate sizes for the default state and when the header is "scrolled" (pinned, smaller).
+- **Menu** — alignment (left / middle / right), font size, letter spacing, uppercase, and font weight.
+
+### Footer Settings
+
+Controls the bottom of every page:
+
+- **Footer Pattern** — choose one of your reusable patterns as the footer. See the *Patterns* page for how this works.
+- **Footer Pattern Width** — how wide the footer content sits on the page.
+- **Vertical Footer Padding** — how much space sits above and below the footer content.
+- **Display Copyright** and **Copyright Text** — the small print at the bottom. Use `YYYY` anywhere in the copyright text and the site will substitute the current year.
+- **Social Media Links** — Facebook, Twitter, Instagram, and YouTube URLs.
+
+### Hero Settings
+
+The large banner at the top of most pages:
+
+- **Default Height** — how tall the hero is when it has a background image, as a percentage of the visitor's screen.
+- **Text-Only Hero Height** — the height when there is no background image.
+- **Minimum Height** — a floor so the hero never collapses too small on phones.
+- **Background Opacity** — how dark the overlay over the background image is.
+
+Individual pages can override these in the block editor — see the *Blocks* page.
+
+### Breadcrumbs Settings
+
+Where the trail of links above the page title is shown (above the hero, on top of the hero, at the bottom of the hero, below the hero, or hidden) and the background opacity of the breadcrumb bar.
+
+## How each kind of content looks
+
+The Customizer has dedicated sections for the look of each content type.
+
+### Sermon Archive Styles
+
+The sermons list page. Choose how many columns of sermon cards to show on tablet and desktop, the aspect ratio of each card's image, how text sits over or under the image, and the order of the title, date, and pastor on each card.
+
+You can also pick a **Card Contents Pattern** here — see *Patterns* for how using a pattern turns a sermon tile into a layout you design yourself.
+
+### Sermon Page Styles
+
+The look of an individual sermon page. Pick a default sermon image (used when a sermon has no featured image), the order of the date / pastor / series / passage details, and how many columns the sermon body content is laid out in.
+
+You can also pick a **Sermon Contents Pattern** here to replace the built-in layout entirely with one you design.
+
+### Sermon Series Settings
+
+A default image for sermon series that do not have a featured image, and the aspect ratio for series cards.
+
+### Staff Page
+
+Controls staff member pages. Lets you pick a **Staff Contents Pattern** to replace the built-in layout for each staff member's page with a pattern you design.
+
+### Events Settings
+
+Currently controls the border width on the events calendar block.
+
+## Components
+
+These sections fine-tune individual pieces that can appear on any page.
+
+### Form Settings
+
+Form-input styling, including whether labels appear above their input or to the left.
+
+### Notifications Settings
+
+Padding for the notification toasts that appear in the lower-right corner of the public site. The colors come from *Site Colors*. See *Managing Notifications* for how to create notifications.
+
+### Accordion Settings
+
+The look of the expandable accordion component: border width, title font size, and padding around each accordion title.
+
+### Blockquotes Settings
+
+How blockquotes are styled: maximum width, the size of the decorative quotation marks, and which of your configured fonts is used for the quote.
+
+### Pagination Styles
+
+Color settings for the page-number controls at the bottom of long lists.
+
+## What gets saved when you click Publish
+
+When you click **Publish**, two things happen:
+
+- Your settings are stored in the database, so the site uses them everywhere.
+- A static stylesheet is rebuilt in the background so visitors get the new look immediately, without having to wait for the site to assemble it on every page load.
+
+If you ever need to back up or transfer your Customizer choices, see the *Theme Settings* page — it has an export/import tool.

--- a/admin-panel/documentation/pages/4-theme-settings.md
+++ b/admin-panel/documentation/pages/4-theme-settings.md
@@ -1,0 +1,39 @@
+# Theme Settings
+
+The **Theme Settings** page (under **Settings → Theme Settings**) is where you turn the theme's content types on and off, and where you back up or restore everything you have configured in the Customizer.
+
+## Enabling content types
+
+The theme adds several optional content types to WordPress: *sermons*, *sermon-series*, *ministries*, *events*, and *staff*. Not every church needs all of them, so this page lets you decide which ones are active.
+
+Tick a content type and it appears in the admin sidebar as its own menu, with its own settings, archive page, and styling options. Untick a content type and it is hidden everywhere — the menu disappears, its Customizer sections are no longer shown, and the rest of the admin gets a little simpler.
+
+By default, **sermons** and **staff** are enabled.
+
+A few things to know:
+
+- Disabling a content type does not delete the entries you have already created — it only hides them. If you tick the box again later, they reappear.
+- A few features always stay on no matter what: **Layouts** and **Notifications**. These are part of the theme's foundation.
+- If you enable a new content type, the theme may prompt you to also create its archive page (for example, a page with the slug `sermons` for the sermons archive). The reminder appears as a notice at the top of the admin, with a button to create the page for you.
+
+Click **Save Changes** to apply your choices.
+
+## Backing up and restoring your settings
+
+Below the Enabled Post Types table you will see an **Export / Import** area with two small forms. These cover almost every styling and configuration choice you make in **Appearance → Customize** — colors, fonts, header, footer, hero, cards, and the like.
+
+### Exporting
+
+Click **Export Theme Settings** to download a single file containing all of your Customizer settings. Keep this file somewhere safe — it is your backup.
+
+This is also how you copy settings from one site to another. For example, export from a staging site and import on the live site to bring your look across in one step.
+
+### Importing
+
+Click **Choose File**, pick a previously-exported settings file, and click **Import Theme Settings**. The site immediately switches to those settings.
+
+A few things to know:
+
+- Import **overwrites** your current Customizer settings. If you have not exported your current state, you may want to do that first as a backup.
+- Importing does not change any of your actual content (sermons, events, pages, posts, and so on). It only restores styling and configuration.
+- The recommended workflow is **export → keep the file → import**. Hand-editing the file is not supported.

--- a/admin-panel/documentation/pages/5-blocks.md
+++ b/admin-panel/documentation/pages/5-blocks.md
@@ -1,0 +1,86 @@
+# Blocks
+
+The theme adds extra **blocks** to the WordPress editor — small drop-in pieces of content like a list of upcoming events, a sermons grid, a calendar, or a contact form. You add them the same way as any other block: click the **+** button in the editor and search for the block by name.
+
+Most theme blocks are listed under their own name in the inserter. The pattern-only blocks (Sermon Audio, Sermon Pastor, and so on) are only useful inside a pattern — see the *Patterns* page for those.
+
+## Content blocks
+
+### Latest Sermons
+
+Shows the most recent sermons as a grid of cards. The editor sidebar lets you set:
+
+- **Number of sermons** to display.
+- **Number of columns** to lay them out in.
+- A **Sermon Pattern** to use for each card — if you choose one of your patterns, the block uses your design for the tile (see *Patterns*).
+
+### Upcoming Events
+
+Shows the next few events as a grid of cards, ordered by date. The sidebar lets you set:
+
+- **Number of events** to display.
+- **Number of columns** to lay them out in.
+
+### Church Calendar
+
+A full interactive calendar that fills itself in with all of your published events. Useful on a dedicated *Calendar* page. The calendar's borders are styled in **Appearance → Customize → Events Settings**.
+
+### Staff Members
+
+Shows a selected group of staff members as cards. In the sidebar:
+
+- **Staff IDs** — pick which staff members appear.
+- **Number of columns** to lay them out in.
+- A **Staff Pattern** to design the card yourself (see *Patterns*).
+
+### Lorem Ipsum
+
+A small helper for designers: drop it in and it fills itself with placeholder text. Set the number of paragraphs in the sidebar. Useful while building patterns or layouts.
+
+## Spacing settings on every block
+
+Open the editor sidebar for **any** block on the page — even the built-in WordPress blocks — and you will find a **Spacing** panel added by the theme. It contains:
+
+- **Block container** — toggle between a centered, contained width (the same as your page content) and a full-width block.
+- **Bottom margin** — how much space sits below the block (and a separate value for desktop, so you can space things out more generously on larger screens).
+- **Block padding** — how much space sits inside the block, around its content.
+
+These give you a consistent vertical rhythm without having to think about pixel values.
+
+## Per-page hero settings
+
+When a page has a hero (the big banner at the top), you can override the site-wide hero defaults for that one page. With nothing selected in the editor, open the editor sidebar and look for the **Hero Settings** panel. You can set:
+
+- A different **background image**.
+- A different **text color**, **background color**, and **opacity** for the overlay.
+- A different **height**.
+
+If you do not override any of these, the page uses the values from **Appearance → Customize → Hero Settings**.
+
+## Member-only content
+
+The **Member Settings** panel (also in the editor sidebar) lets you mark an individual page as members-only. Use this for content that should not be public — visitors who are not logged in will not see it.
+
+## The contact form
+
+Drop a **Form** block onto a page and you get a form container you can fill with input blocks. The form's sidebar has a **Form Submission** panel where you choose what happens when someone submits it:
+
+- **Email** — sends the submission to one or more email addresses. Type the addresses you want notifications to go to.
+- **Endpoint** — sends the submission to a URL you provide. Use this if your church has its own forms system or signup service.
+
+Give the form a **Form Name** (used in subject lines and labels) and a **Form ID** if you want to refer to it elsewhere.
+
+Inside the form you can use:
+
+- **Text Input** — a single-line text field. Set the label, the field name, optional placeholder, and whether the field is required.
+- **Email** — same as Text Input, but for email addresses. Validates the format automatically.
+- **Select** — a dropdown. The **options** field takes a comma-separated list of choices.
+- **Checkbox** — a single checkbox, with a label and a name.
+- **Submit** — the submit button. Set its text and pick between a primary or secondary style.
+- **Form Response** — the box that appears with a success or error message after someone submits. Set the message text, alignment, and border size.
+
+The first time you add a Form block the inner blocks come pre-filled with a sensible starter layout, so you usually only need to adjust labels and submission settings.
+
+## What about the "Sermon Audio", "Sermon Pastor" blocks?
+
+These are **pattern-only blocks** — they only do something useful inside a pattern that is being used as a sermon tile or sermon page. See the *Patterns* page for what each one does and how to use them.

--- a/admin-panel/documentation/pages/managing-events.md
+++ b/admin-panel/documentation/pages/managing-events.md
@@ -1,0 +1,56 @@
+# Managing Events
+
+The Events content type lets you publish things happening at the church — services, meetings, conferences, fellowship dinners, anything with a date. Each event has its own page, and there is an automatically-updated calendar block you can drop on any page.
+
+## Adding an event
+
+1. In the admin sidebar, click **Events → Add New**.
+2. Set the **title** of the event.
+3. Use the main editor for a description, schedule, registration link, or anything else visitors should know.
+4. Set a **featured image** if you have one — it becomes the hero image on the event's page and the image on event cards.
+5. Open the **Event Details** box in the side panel and fill in the date, optional recurrence, and location (covered below).
+6. Click **Publish**.
+
+## The Event Details box
+
+This is the side-panel box that turns a regular post into an event.
+
+### Event Date
+
+A single date picker for when the event happens. This is what the site uses to sort upcoming events and to decide when an event is in the past.
+
+### Recurring value (optional)
+
+For an event that repeats on a regular schedule, fill in this field with just the **number and unit** of how often it repeats. For example:
+
+- `1 week` — every week.
+- `2 weeks` — every other week.
+- `1 month` — once a month.
+- `3 days` — every three days.
+
+Write only the number and unit — not `every 2 weeks` or `bi-weekly`. The theme uses the value the same way a calendar app would.
+
+If the recurring value is set, then once the event date has passed, the date automatically rolls forward to the next occurrence. So a weekly Sunday service can be created once and the date will keep moving forward on its own.
+
+Leave the recurring value blank for one-off events.
+
+### Location
+
+A free-text field for where the event is. You can write a plain address, but you can also paste a **Google Maps embed URL** here and the theme will display an embedded map at the bottom of the event's page.
+
+## What appears on an event's page
+
+The built-in event layout shows the title, featured image, the date and location, the description from the main editor, and (when the location is a Google Maps embed URL) an embedded map.
+
+## Showing events elsewhere on the site
+
+Two blocks make it easy to surface events from any page:
+
+- **Calendar** — a full interactive calendar with every published event on it. Drop it on a page (for example a dedicated *Calendar* page) and the calendar fills itself in.
+- **Upcoming Events** — a small grid of the next few events, ordered by date. Use it on the homepage or in a sidebar layout to highlight what is coming up.
+
+See the *Blocks* page for what each block offers.
+
+## Styling the calendar
+
+The look of the events calendar block is configured in **Appearance → Customize → Events Settings**.

--- a/admin-panel/documentation/pages/managing-notifications.md
+++ b/admin-panel/documentation/pages/managing-notifications.md
@@ -1,21 +1,25 @@
 # Managing Notifications
 
-Site notifications appear as dismissible **toasts** in the lower-right corner of the public site.
+Site notifications appear as dismissible **toasts** in the lower-right corner of the public site. Each published notification becomes one toast.
 
 ## Creating a notification
 
 1. Go to **Notifications** in the admin sidebar and click *Add New*.
 2. Set the **title** and **content** — these become the toast heading and body.
-3. Open the **Notification Details** box and set the start date, end date, and type.
+3. Open the **Notification Details** box on the side and set a **Start Date**, **End Date**, and **Type**.
 
-The **Type** can be `info`, `notice`, or `emergency`. Will default to info.
+The **Type** chooses which icon and color the toast uses:
+
+- **Info** — the default, used for general announcements.
+- **Notice** — for things you want people to pay attention to but that are not urgent.
+- **Emergency** — for the most urgent messages.
 
 ## How it behaves
 
-- An hourly job publishes a notification once its start date has passed, and deletes it once its end date has passed.
-- A notification with no start or end date is always published and is never automatically removed.
-- Visitors can dismiss a notification; it then stays hidden for the rest of their browsing session.
+- An hourly background job publishes a notification once its **Start Date** has passed, and deletes it permanently once its **End Date** has passed (after end-of-day on that date).
+- A notification missing either a Start Date or an End Date is **skipped** by the background job. It will not be published or deleted automatically — you would need to publish it (or remove it) yourself, just like a regular post. If you want a notification to come and go on its own, give it both dates.
+- The toast appears for every visitor until they dismiss it. Once a visitor clicks the close button on a toast, it stays hidden for the rest of their browsing session (it comes back if they close and reopen the browser).
 
 ## Appearance
 
-Notification appearance is configurable under **Appearance → Customize → Notifications**.
+How the toasts look — colors, spacing, and padding — is configurable under **Appearance → Customize → Notifications Settings**, and the colors used for each type come from the *Site Colors* section.

--- a/admin-panel/documentation/pages/managing-sermons.md
+++ b/admin-panel/documentation/pages/managing-sermons.md
@@ -1,0 +1,63 @@
+# Managing Sermons
+
+Sermons are one of the main content types in the theme. Each sermon has its own page on the site (with the audio player, pastor, and series shown), and the full list of sermons appears on the sermons archive page.
+
+This page covers adding sermons manually and setting up automatic sermon importing from a feed.
+
+## Adding a sermon by hand
+
+1. In the admin sidebar, click **Sermons → Add New**.
+2. Set the **title** — usually the sermon's title.
+3. Use the main editor area for the sermon's description, transcript, or notes.
+4. Set a **featured image** in the sidebar. If you do not, the *Default Sermon Image* from the *Sermon Page Styles* Customizer section will be used instead.
+5. In the side panel, choose the **Pastor** — a list of everyone in *Staff*. Pick one.
+6. In the side panel, choose the **Related Sermon Series** if the sermon belongs to a series. (You can leave this blank if the sermon is a one-off.)
+7. The **publish date** controls where the sermon shows up in the sermons list, so set it to the date the sermon was preached if it is different from today.
+8. Click **Publish**.
+
+## Importing sermons automatically from a feed
+
+If your church uses a service that publishes a podcast-style sermon feed (an RSS or XML feed), the theme can pull sermons in for you automatically — you do not need to add each one by hand.
+
+### Setting up the feed
+
+1. Go to **Sermons → Sermon Settings**.
+2. Paste the URL of your sermon feed into the **Sermon Feed** field. (Most feeds end in `.xml`.)
+3. Click **Save Changes**.
+
+Leave the field blank and the theme assumes you are uploading sermons manually — no feed is checked.
+
+### How automatic import works
+
+- A background job runs once a week (Sunday afternoon) and fetches the feed.
+- Any sermons in the feed that the site does not already have are added as new sermons. Existing sermons are left alone, so re-running the import will never create duplicates.
+- For each new sermon, the theme captures the title, description, publish date, and audio link from the feed.
+- The theme also reads the pastor's name from the feed and links the sermon to the matching staff member. If no staff member with that name exists yet, the theme creates one automatically — you can fill in their photo, bio, and other details later.
+
+### Fetching updates manually
+
+If you do not want to wait for the weekly run, the **Sermon Settings** page shows a **Fetch Sermons** button (only when a feed URL is set). Click it and the import runs immediately.
+
+## What appears on a sermon's page
+
+The built-in sermon layout shows:
+
+- The sermon's featured image as the hero.
+- The title.
+- The publish date, the pastor's name, the series the sermon belongs to, and the Bible passage (if set).
+- The sermon's description or notes.
+- An audio player and a download link, if an audio URL was captured during import.
+
+You can change the order of date / pastor / series / passage in **Appearance → Customize → Sermon Page Styles**. If you want a completely different layout, see the *Patterns* page — the *Sermon Contents Pattern* setting lets you replace the built-in layout with one you design.
+
+## What the sermons list looks like
+
+The sermons archive page (the page with the slug `sermons`) shows every published sermon as a card in a grid. The look of these cards — how many columns, the card's shape, whether the title sits on top of the image or below it, and what details appear — is controlled in **Appearance → Customize → Sermon Archive Styles**.
+
+If you would rather design the card yourself, use the *Card Contents Pattern* setting there. See *Patterns* for how that works.
+
+## Sermon series
+
+A sermon series is a separate content type — go to **Sermon Series → Add New** to create one. Each series has its own page and the sermons assigned to it list there.
+
+> Tip: Use the **Sermon Series Default Image** in the Customizer to provide a fallback image so series that have not been given a featured image still look polished in lists.


### PR DESCRIPTION
## Summary

Audits the current admin-facing documentation in `admin-panel/documentation/pages/` against the codebase and brings it in line with what site administrators can actually do today. Documentation-only — no source-code changes.

### Updated pages

- **1-getting-started.md** — page was empty; now walks through permalinks, archive pages, the 404 page, content-type selection, menu setup, and initial Customizer steps.
- **managing-notifications.md** — corrects the inaccurate "notifications without start/end dates are always published" claim (the hourly job actually skips them); expands on each notification type and on the dismiss behavior.

### New pages

- **3-customizer.md** — overview of every Customizer section: brand/identity, layout, per-content-type styling, and component styling.
- **4-theme-settings.md** — the \`Settings → Theme Settings\` page: enabling and disabling content types, plus exporting and importing all Customizer settings.
- **5-blocks.md** — the theme's editor blocks (Latest Sermons, Upcoming Events, Calendar, Staff Members, Lorem Ipsum, the Form block family, the per-block Spacing panel, the Hero Settings and Member Settings sidebar panels).
- **managing-sermons.md** — adding sermons by hand, the Pastor and Related Sermon Series side-panel fields, automatic RSS feed import via \`Sermons → Sermon Settings\`, manual fetch, and the sermon series content type.
- **managing-events.md** — the Event Details box: date, recurring value (with the \`2 weeks\`-style format), and the location field including its Google Maps embed support.

### Audience

All pages are written for non-technical site administrators and editors — plain language, focused on what they see and click in the admin, with no code, file paths, or option keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)