### PR TITLE
Sync documentation with code

### DIFF
--- a/admin-panel/documentation/pages/3-customizer.md
+++ b/admin-panel/documentation/pages/3-customizer.md
@@ -96,7 +96,7 @@ Controls staff member pages. Lets you pick a **Staff Contents Pattern** to repla
 
 ### Events Settings
 
-Currently controls the border width on the events calendar block.
+Controls the **Church Calendar** block: the border width around the calendar, and an *Events Section Colors* group for the calendar's colors — the header background, the outline around each day, and the two alternating background colors used to differentiate weeks.
 
 ## Components
 

--- a/admin-panel/documentation/pages/5-blocks.md
+++ b/admin-panel/documentation/pages/5-blocks.md
@@ -41,21 +41,26 @@ A small helper for designers: drop it in and it fills itself with placeholder te
 
 Open the editor sidebar for **any** block on the page — even the built-in WordPress blocks — and you will find a **Spacing** panel added by the theme. It contains:
 
-- **Block container** — toggle between a centered, contained width (the same as your page content) and a full-width block.
-- **Bottom margin** — how much space sits below the block (and a separate value for desktop, so you can space things out more generously on larger screens).
-- **Block padding** — how much space sits inside the block, around its content.
+- **Element Vertical Padding** — how much space sits inside the block, above and below its content. Choose *Theme Default*, *None*, *Small*, *Medium*, or *Large*.
+- **Border Radius** — how rounded the block's corners are. Choose *None*, *Small*, *Medium*, or *Large*.
+- **Is Contained Width?** — when on, the block sits at the centered, contained width (the same as your page content); when off, it stretches full width.
+- **Mobile Margin** — how much space sits below the block on phones and tablets.
+- **Desktop Margin** — the equivalent for larger screens, so you can space things out more generously on desktop.
 
 These give you a consistent vertical rhythm without having to think about pixel values.
 
 ## Per-page hero settings
 
-When a page has a hero (the big banner at the top), you can override the site-wide hero defaults for that one page. With nothing selected in the editor, open the editor sidebar and look for the **Hero Settings** panel. You can set:
+When a page has a hero (the big banner at the top), you can override the site-wide hero defaults for that one page. Open the editor's **three-dot menu** in the top-right and choose **Hero Settings** — a dedicated sidebar slides in. You can set:
 
-- A different **background image**.
-- A different **text color**, **background color**, and **opacity** for the overlay.
-- A different **height**.
+- **Opacity** — how dark the overlay sits over the background image.
+- **Hero Background Color** — the color shown behind the hero (visible when there is no featured image, or through the overlay).
+- **Hero Text Color** — the color of the title and breadcrumbs over the hero.
+- **Hero Height** — how tall the hero is on this page.
 
-If you do not override any of these, the page uses the values from **Appearance → Customize → Hero Settings**.
+A **Reset Hero Settings To Defaults** button at the top of the sidebar clears every override on the current page in one click.
+
+The page's **featured image** is what shows as the hero background image — set it the usual way from the document settings sidebar. Anything you do not override here uses the values from **Appearance → Customize → Hero Settings**.
 
 ## Member-only content
 


### PR DESCRIPTION
## Summary

Audit of `admin-panel/documentation/pages/` against the current code surfaced three substantive discrepancies in admin-facing docs. This PR updates them; everything else was already accurate.

### Updated

- **`3-customizer.md` — Events Settings.** Section now also exposes calendar colors under an *Events Section Colors* group (header background, outline, two alternating week backgrounds). Doc previously said only the border width was configurable.
- **`5-blocks.md` — Spacing panel on every block.** Labels admins see in the editor are *Element Vertical Padding*, *Border Radius*, *Is Contained Width?*, *Mobile Margin*, *Desktop Margin*. The doc used older, internal-sounding names ("Block container", "Block padding", "Bottom margin") and was missing the *Border Radius* option entirely.
- **`5-blocks.md` — Per-page Hero Settings.** Rewritten to match the actual sidebar: it opens from the editor's three-dot menu (it is a *PluginSidebar*, not a panel), and offers Opacity, Hero Background Color, Hero Text Color, Hero Height, plus a Reset button. Removed the inaccurate "background image" override claim (the per-page background image is the page's featured image, set the normal way).

### Not changed

Other suspected gaps turned out to already be covered: the Emergency notification type, recurring-event date roll-forward, notification cron behavior, and the location of the Sermon Settings sub-page are all documented correctly. Staff and Ministries CPTs have no custom metaboxes; the ways admins interact with them are already covered in the Sermons, Blocks, and Customizer pages.

## Test plan

- [ ] Open **Documentation → Customizer** in the admin and confirm the Events Settings entry reads accurately against **Appearance → Customize → Events Settings**.
- [ ] Open **Documentation → Blocks** and confirm the Spacing panel descriptions match the labels shown when editing any block in the editor.
- [ ] In the block editor, open the three-dot menu and confirm **Hero Settings** opens a sidebar with Opacity, Hero Background Color, Hero Text Color, Hero Height, and a reset button — matching the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)